### PR TITLE
Update dependency (LoggerAPI 2.0.0); Update README to reflect Swift 5.2 minimum requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Kitura/LoggerAPI.git", .upToNextMajor(from: "1.9.200"))
+        .package(url: "https://github.com/Kitura/LoggerAPI.git", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 Resolves commonly used paths, including the project, executable and working directories.
 
 ## Version
-The latest release of `FileKit` (0.x.x) runs on Swift 4.0 and newer, on both macOS and Ubuntu Linux.
+The latest release of `FileKit` (0.x.x) runs on Swift 5.2 and newer, on both macOS and Ubuntu Linux.
 
 ## Usage
 


### PR DESCRIPTION
Update dependency (LoggerAPI 2.0.0); Update README to reflect Swift 5.2 minimum requirement